### PR TITLE
Fix licence info generation in Maven POM

### DIFF
--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -48,7 +48,7 @@ def pomConfig = {
     url 'https://github.com/aalmiray/markdown-gradle-plugin'
     inceptionYear '2013'
     licenses {
-        license {
+        delegate.license {
             name 'The Apache Software License, Version 2.0'
             url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
             distribution 'repo'


### PR DESCRIPTION
The currently published POMs are invalid according to the XSD, and are
rejected by some artifact managers (e.g. Artifactory). The licence info is
sitting directly inside the <licenses> tag, rather than in a nested
<license> tag.

The builder notation is picking up the licence plugin object rather than
generating a new property. This fixes that by referencing delegate.licence
instead.
