### PR TITLE
Issue 7: URLs ending in '.md' and '.markdown' rendered as '.html'

### DIFF
--- a/src/main/groovy/org/kordamp/gradle/markdown/Conversion.groovy
+++ b/src/main/groovy/org/kordamp/gradle/markdown/Conversion.groovy
@@ -49,6 +49,10 @@ enum Conversion {
         targetExtension
     }
 
+    List<String> extensions() {
+        extensions
+    }
+
 //    String exclusions() {
 //        extensions.collect([]) { '**/*' + it }.join(', ')
 //    }

--- a/src/main/groovy/org/kordamp/gradle/markdown/Conversion.groovy
+++ b/src/main/groovy/org/kordamp/gradle/markdown/Conversion.groovy
@@ -49,6 +49,7 @@ enum Conversion {
         targetExtension
     }
 
+    @SuppressWarnings('ConfusingMethodName')
     List<String> extensions() {
         extensions
     }

--- a/src/main/groovy/org/kordamp/gradle/markdown/MarkdownProcessor.groovy
+++ b/src/main/groovy/org/kordamp/gradle/markdown/MarkdownProcessor.groovy
@@ -64,7 +64,7 @@ class MarkdownProcessor {
         // we have to lock, because pegdown is not thread-safe<
         try {
             processorLock.lock()
-            result = p.markdownToHtml((String) text)
+            result = p.markdownToHtml((String) text, new MarkdownToHtmlLinkRenderer() )
         } finally {
             processorLock.unlock()
         }

--- a/src/main/groovy/org/kordamp/gradle/markdown/MarkdownToHtmlLinkRenderer.groovy
+++ b/src/main/groovy/org/kordamp/gradle/markdown/MarkdownToHtmlLinkRenderer.groovy
@@ -1,0 +1,46 @@
+package org.kordamp.gradle.markdown
+
+import org.pegdown.LinkRenderer
+import org.pegdown.ast.AutoLinkNode
+import org.pegdown.ast.ExpLinkNode
+import org.pegdown.ast.RefLinkNode
+import org.pegdown.ast.WikiLinkNode
+
+import static org.pegdown.LinkRenderer.Rendering
+
+/**
+ * @author Ed MacDonald
+ */
+class MarkdownToHtmlLinkRenderer extends LinkRenderer {
+    private Conversion conversion = Conversion.MARKDOWN
+
+    @Override
+    Rendering render(AutoLinkNode node) {
+        return adjustHref(super.render(node))
+    }
+
+    @Override
+    Rendering render(ExpLinkNode node, String text) {
+        return adjustHref(super.render(node, text))
+    }
+
+    @Override
+    Rendering render(RefLinkNode node, String url, String title, String text) {
+        return adjustHref(super.render(node, url, title, text))
+    }
+
+    @Override
+    Rendering render(WikiLinkNode node) {
+        return adjustHref(super.render(node))
+    }
+
+    // Assumes each extension starts with "."
+    private Rendering adjustHref( Rendering rendering ) {
+        if(conversion.extensions().size() > 0) {
+            def regex =  conversion.extensions().join("|\\")
+            regex = "(\\" + regex + ")\$"
+            rendering.href = rendering.href.replaceFirst(regex, conversion.targetExtension())
+        }
+        return rendering
+    }
+}

--- a/src/main/groovy/org/kordamp/gradle/markdown/MarkdownToHtmlLinkRenderer.groovy
+++ b/src/main/groovy/org/kordamp/gradle/markdown/MarkdownToHtmlLinkRenderer.groovy
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.kordamp.gradle.markdown
 
 import org.pegdown.LinkRenderer

--- a/src/main/groovy/org/kordamp/gradle/markdown/MarkdownToHtmlLinkRenderer.groovy
+++ b/src/main/groovy/org/kordamp/gradle/markdown/MarkdownToHtmlLinkRenderer.groovy
@@ -12,35 +12,35 @@ import static org.pegdown.LinkRenderer.Rendering
  * @author Ed MacDonald
  */
 class MarkdownToHtmlLinkRenderer extends LinkRenderer {
-    private Conversion conversion = Conversion.MARKDOWN
+    private final Conversion conversion = Conversion.MARKDOWN
 
     @Override
     Rendering render(AutoLinkNode node) {
-        return adjustHref(super.render(node))
+        adjustHref(super.render(node))
     }
 
     @Override
     Rendering render(ExpLinkNode node, String text) {
-        return adjustHref(super.render(node, text))
+        adjustHref(super.render(node, text))
     }
 
     @Override
     Rendering render(RefLinkNode node, String url, String title, String text) {
-        return adjustHref(super.render(node, url, title, text))
+        adjustHref(super.render(node, url, title, text))
     }
 
     @Override
     Rendering render(WikiLinkNode node) {
-        return adjustHref(super.render(node))
+        adjustHref(super.render(node))
     }
 
     // Assumes each extension starts with "."
     private Rendering adjustHref( Rendering rendering ) {
         if(conversion.extensions().size() > 0) {
-            def regex =  conversion.extensions().join("|\\")
-            regex = "(\\" + regex + ")\$"
+            def regex =  conversion.extensions().join('|\\')
+            regex = '(\\' + regex + ')\$'
             rendering.href = rendering.href.replaceFirst(regex, conversion.targetExtension())
         }
-        return rendering
+        rendering
     }
 }


### PR DESCRIPTION
I believe this addresses the following issue:
https://github.com/aalmiray/markdown-gradle-plugin/issues/7