### PR TITLE
Upgrade to com.overzealous:remark:1.0.0 which is in jcenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ repositories {
 
 dependencies {
     compile gradleApi()
-    compile 'com.overzealous:remark:0.9.3',
+    compile 'com.overzealous:remark:1.0.0',
         'org.jsoup:jsoup:1.8.1',
         'org.apache.commons:commons-lang3:3.3.2',
         'org.pegdown:pegdown:1.5.0'


### PR DESCRIPTION
Based on: https://bitbucket.org/OverZealous/remark/issues/4/publish-artifacts-to-maven-ivy-repo#comment-20898525

I think this change fixes issue #16 