### PR TITLE
Consider anchor references when replacing markdown extensions

### DIFF
--- a/src/main/groovy/org/kordamp/gradle/markdown/MarkdownToHtmlLinkRenderer.groovy
+++ b/src/main/groovy/org/kordamp/gradle/markdown/MarkdownToHtmlLinkRenderer.groovy
@@ -53,8 +53,9 @@ class MarkdownToHtmlLinkRenderer extends LinkRenderer {
     private Rendering adjustHref( Rendering rendering ) {
         if(conversion.extensions().size() > 0) {
             def regex =  conversion.extensions().join('|\\')
-            regex = '(\\' + regex + ')\$'
-            rendering = new Rendering(rendering.href.replaceFirst(regex, conversion.targetExtension()), rendering.text)
+            regex = '(\\' + regex + ')(\$|#)'
+            def replacement = conversion.targetExtension() + '\$2'
+            rendering = new Rendering(rendering.href.replaceFirst(regex, replacement), rendering.text)
         }
         rendering
     }

--- a/src/test/groovy/org/kordamp/gradle/markdown/MarkdownToHtmlLinkRendererSpec.groovy
+++ b/src/test/groovy/org/kordamp/gradle/markdown/MarkdownToHtmlLinkRendererSpec.groovy
@@ -41,4 +41,22 @@ class MarkdownToHtmlLinkRendererSpec  extends Specification {
         then:
         result.href.equals("test.html")
     }
+
+    def "AutoLinkNode suffix is replaced when an anchor is present"(){
+        when:
+        def renderer = new MarkdownToHtmlLinkRenderer()
+        def result = renderer.render(new AutoLinkNode("test.md#anchor"))
+
+        then:
+        result.href.equals("test.html#anchor")
+    }
+
+    def "AutoLinkNode suffix .mde is not replaced"(){
+        when:
+        def renderer = new MarkdownToHtmlLinkRenderer()
+        def result = renderer.render(new AutoLinkNode("test.mde"))
+
+        then:
+        result.href.equals("test.mde")
+    }
 }


### PR DESCRIPTION
The regex used for matching extensions in links requires the href to end
immediately after the extension. Links with appended HTML anchor
references therefore will not be matched.

This is fixed by allowing both the end-of-string as well as a number
sign to be matched.